### PR TITLE
replace mcode github references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 - [Node.js](https://nodejs.org/en/download/) (LTS edition, currently 20.x)
 - At least one of the following matching services:
-  - [BreastCancerTrials](https://github.com/mcode/clinical-trial-matching-service-breastcancertrials.org)
-  - [TrialScope](https://github.com/mcode/clinical-trial-matching-service-trialscope)
-  - [TrialJectory](https://github.com/mcode/clinical-trial-matching-service-trialjectory)
+  - [BreastCancerTrials](https://github.com/EssexManagement/clinical-trial-matching-service-breastcancertrials.org)
+  - [TrialScope](https://github.com/EssexManagement/clinical-trial-matching-service-trialscope)
+  - [TrialJectory](https://github.com/EssexManagement/clinical-trial-matching-service-trialjectory)
 
 ## Testing with a launcher
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mcode/clinical-trial-matching-app.git"
+    "url": "https://github.com/EssexManagement/clinical-trial-matching-app.git"
   },
   "scripts": {
     "build": "next build",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -126,7 +126,7 @@ These options control the Linux installer:
 
 ## wrappers.json Configuration
 
-`wrappers.json` is a simple JSON file. The base value is an object, where each key gives the name a wrapper will be installed to. This name is also used to determine the GitHub URL of the wrapper, which currently must be `https://github.com/mcode/clinical-trial-matching-service-<name>.git`. (This will likely be updated to allow a specific URL to be used to override the default.)
+`wrappers.json` is a simple JSON file. The base value is an object, where each key gives the name a wrapper will be installed to. This name is also used to determine the GitHub URL of the wrapper, which currently must be `https://github.com/EssexManagement/clinical-trial-matching-service-<name>.git`. (This will likely be updated to allow a specific URL to be used to override the default.)
 
 The value for each key may either be `false` or `null` to skip that wrapper (when overriding from `wrappers.local.json`), or an object with the following keys:
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -285,7 +285,10 @@ class CTMSWebApp {
 
   async needsDependenciesUpdated(installer) {
     // Really this could just return the promise directly, but it reads more clearly with the async/await
-    return await isFileOutOfDate(installer.joinPath(this.path, 'package.json'), installer.joinPath(this.path, 'node_modules'));
+    return await isFileOutOfDate(
+      installer.joinPath(this.path, 'package.json'),
+      installer.joinPath(this.path, 'node_modules')
+    );
   }
 
   async runInstallDependencyCommand(installer) {
@@ -458,7 +461,7 @@ class CTMSWrapper extends CTMSWebApp {
       name,
       `clinical-trial-matching-service-${name}`,
       branch,
-      `https://github.com/mcode/clinical-trial-matching-service-${name}.git`
+      `https://github.com/EssexManagement/clinical-trial-matching-service-${name}.git`
     );
     this.localEnv = localEnv;
   }
@@ -500,7 +503,7 @@ class CTMSApp extends CTMSWebApp {
       'clinical-trial-matching-app',
       'clinical-trial-matching-app',
       CTM_APP_BRANCH,
-      'https://github.com/mcode/clinical-trial-matching-app.git'
+      'https://github.com/EssexManagement/clinical-trial-matching-app.git'
     );
   }
 
@@ -822,7 +825,9 @@ ${frontendConfig}
       const newInstallScriptStats = await fs.stat(scriptPath);
       if (installScriptStats.mtime < newInstallScriptStats.mtime) {
         console.log('Install script may have updated! Attempting to relaunch installer.');
-        console.log(`(Old mtime was ${installScriptStats.mtime.toString()}, new is ${newInstallScriptStats.mtime.toString()}.)`);
+        console.log(
+          `(Old mtime was ${installScriptStats.mtime.toString()}, new is ${newInstallScriptStats.mtime.toString()}.)`
+        );
         // Concat creates a new copy of the array
         const newArgs = process.argv.slice(1);
         newArgs.push('--no-install-update-check');

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -327,7 +327,7 @@ EnableFSMonitor=Disabled
             # If the script does not exist, we need to clone it.
             Push-Location $this.InstallPath
             try {
-                git clone 'https://github.com/mcode/clinical-trial-matching-app.git'
+                git clone 'https://github.com/EssexManagement/clinical-trial-matching-app.git'
                 if ($LastExitCode -ne 0) {
                     throw 'Failed to clone webapp directory (could not bootstrap remaining install)'
                 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -244,7 +244,7 @@ cd "$CTMS_DIR"
 # Bootstrap the CTMS directory if necessary
 if ! [ -f "$CTMS_DIR/clinical-trial-matching-app/scripts/install.js" ] ; then
   pushd "$CTMS_DIR"
-  git clone 'https://github.com/mcode/clinical-trial-matching-app.git'
+  git clone 'https://github.com/EssexManagement/clinical-trial-matching-app.git'
   popd
 fi
 sudo -u "$CTMS_USER" node "$CTMS_DIR/clinical-trial-matching-app/install.js" --install-dir "$CTMS_DIR" --extra-ca-certs "$EXTRA_CA_CERTS_FILE" $*

--- a/scripts/zip.js
+++ b/scripts/zip.js
@@ -54,6 +54,10 @@ class CTMSWebApp {
     if (/\.env.*\.local$/.test(file.name)) {
       return true;
     }
+    // Ignore ide files
+    if (/\.vscode/.test(file.name)) {
+      return true;
+    }
     // Ignore web.config
     if (file.name == 'web.config') {
       return true;
@@ -109,7 +113,7 @@ class Zipper {
     this.path = path;
     this.zipOutputStream = new ZipArchiveOutputStream({ zlib: { level: 9 } });
     let writeStream = fs.createWriteStream(destination);
-    const handleError = (error) => {
+    const handleError = error => {
       if (this.verbose) {
         console.log('Error in ZIP: %o', error);
       }
@@ -181,7 +185,7 @@ class Zipper {
       }
       let readStream = fs.createReadStream(file);
       let resolved = false;
-      readStream.on('error', (err) => {
+      readStream.on('error', err => {
         if (resolved) {
           return;
         }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,0 @@
-sonar.coverage.exclusions=src/__mocks__/**,src/queries/**,src/styles/**,src/pages/**,src/*.ts
-sonar.exclusions=src/**/__tests__/**
-sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.organization=mcode
-sonar.projectKey=mcode_clinical-trial-matching-app
-sonar.sources=src
-sonar.test.inclusions=src/**/__tests__/**
-sonar.tests=src
-sonar.verbose=true


### PR DESCRIPTION
The install.ps1 script should now install from EssexManagement on a clean install. The trial sites use -NoGitPull so this doesn't affect them.